### PR TITLE
feat: expose emit types

### DIFF
--- a/src/OTPInput.vue
+++ b/src/OTPInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, useAttrs, watch, watchEffect } from 'vue'
-import type { Metadata, OTPInputProps } from './types'
+import type { Metadata, OTPInputProps, OTPInputEmits } from './types'
 import { SelectionType } from './types'
 import { REGEXP_ONLY_DIGITS } from './regexp'
 import { syncTimeouts } from './sync-timeouts'
@@ -17,24 +17,7 @@ const props = withDefaults(defineProps<OTPInputProps>(), {
   autocomplete: 'one-time-code',
 })
 
-const emit = defineEmits<{
-  (event: 'complete', value: string): void
-  (event: 'change', e: Event): void
-  (event: 'select', e: Event): void
-  (event: 'input', e: Event): void
-  (event: 'keydown', e: KeyboardEvent): void
-  (event: 'keyup', e: KeyboardEvent): void
-  (event: 'focus', e: FocusEvent): void
-  (event: 'blur', e: FocusEvent): void
-  (event: 'mouseover', e: MouseEvent): void
-  (event: 'mouseleave', e: MouseEvent): void
-  (event: 'mousedown', e: MouseEvent): void
-  (event: 'paste', e: ClipboardEvent): void
-  (event: 'touchend', e: TouchEvent): void
-  (event: 'touchmove', e: TouchEvent): void
-  (event: 'click', e: MouseEvent): void
-  (event: 'dblclick', e: MouseEvent): void
-}>()
+const emit = defineEmits<OTPInputEmits>()
 
 const internalValue = defineModel({ default: '' })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export {
 
 export * from './regexp'
 
-export type { OTPInputProps, SlotProps, RenderProps } from './types'
+export type { OTPInputProps, OTPInputEmits, SlotProps, RenderProps } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,25 @@ export interface OTPInputProps extends InputHTMLAttributes {
   containerClass?: string
 }
 
+export interface OTPInputEmits {
+  (event: 'complete', value: string): void
+  (event: 'change', e: Event): void
+  (event: 'select', e: Event): void
+  (event: 'input', e: Event): void
+  (event: 'keydown', e: KeyboardEvent): void
+  (event: 'keyup', e: KeyboardEvent): void
+  (event: 'focus', e: FocusEvent): void
+  (event: 'blur', e: FocusEvent): void
+  (event: 'mouseover', e: MouseEvent): void
+  (event: 'mouseleave', e: MouseEvent): void
+  (event: 'mousedown', e: MouseEvent): void
+  (event: 'paste', e: ClipboardEvent): void
+  (event: 'touchend', e: TouchEvent): void
+  (event: 'touchmove', e: TouchEvent): void
+  (event: 'click', e: MouseEvent): void
+  (event: 'dblclick', e: MouseEvent): void
+}
+
 export enum SelectionType {
   CARET = 0,
   CHAR = 1,


### PR DESCRIPTION
Currently, Vue doesn't have a type helper like `ComponentProps` in React to pull out the types from the components

[vuejs/language-tools/component-type-helpers](https://github.com/vuejs/language-tools/tree/master/packages/component-type-helpers) May help but I'm afraid of TypeScript bugs (complex types) in SFC files

This PR is **exposed** emits for easier usage in `shadcn-vue`

Thanks for the port ❤️ 

---

### One question about `defineModel`,

How it should be handled in the `Wrapper Component` around `<OTPInput />`

See this link, please, and head to the`Controlled` example (v-model is not updating)

https://185015e0.shadcn-vue.pages.dev/docs/components/input-otp.html#controlled