### PR TITLE
docs: fix typo attribute from 'auto-focus' to 'autofocus'

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ import { OTPInput } from 'vue-input-otp'
 <template>
   <form>
     <!-- Pro tip: accepts all common HTML input props... -->
-    <OTPInput auto-focus />
+    <OTPInput autofocus />
   </form>
 </template>
 ```


### PR DESCRIPTION
`auto-focus` is an invalid property, we should use `autofocus` instead.